### PR TITLE
Fixed Transition Double Trigger

### DIFF
--- a/frontend/components/PageTransition.tsx
+++ b/frontend/components/PageTransition.tsx
@@ -1,17 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
 
 export default function PageTransition({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  const [isTransitioning, setIsTransitioning] = useState(false);
-
-  useEffect(() => {
-    setIsTransitioning(true);
-    const timer = setTimeout(() => setIsTransitioning(false), 300);
-    return () => clearTimeout(timer);
-  }, [pathname]);
 
   return (
     <>
@@ -27,27 +19,12 @@ export default function PageTransition({ children }: { children: React.ReactNode
           }
         }
 
-        @keyframes fadeOut {
-          from {
-            opacity: 1;
-            transform: translateY(0);
-          }
-          to {
-            opacity: 0;
-            transform: translateY(-20px);
-          }
-        }
-
         .page-transition-enter {
-          animation: fadeInUp 0.3s ease-out forwards;
-        }
-
-        .page-transition-exit {
-          animation: fadeOut 0.3s ease-out forwards;
+          animation: fadeInUp 0.5s ease-out forwards;
         }
       `}</style>
-      
-      <div className={isTransitioning ? 'page-transition-exit' : 'page-transition-enter'}>
+
+      <div key={pathname} className="page-transition-enter">
         {children}
       </div>
     </>


### PR DESCRIPTION
## Fixed the issue where the page transition animation would double-trigger (fade out -> fade in) on the initial site load.
### Switched to a simpler `key={pathname}` approach to reliably trigger the "Enter" animation on every route change.
### Removed the "Exit" animation to prevent synchronization issues with Next.js App Router.